### PR TITLE
Use named params on resize methods

### DIFF
--- a/ext/tinyimg/tinyimg.c
+++ b/ext/tinyimg/tinyimg.c
@@ -240,7 +240,7 @@ void Init_tinyimg()
   VALUE cTinyimg = rb_define_class("Tinyimg", rb_cObject);
   rb_define_class_under(cTinyimg, "Image", rb_cObject);
 
-  rb_define_method(cTinyimg, "resize!", resize_bang, 2);
+  rb_define_method(cTinyimg, "c_resize!", resize_bang, 2);
   rb_define_method(cTinyimg, "to_jpeg", to_jpeg, -1);
   rb_define_method(cTinyimg, "to_png", to_png, -1);
   rb_define_private_method(cTinyimg, "initialize_copy", initialize_copy, -1);

--- a/lib/tinyimg.rb
+++ b/lib/tinyimg.rb
@@ -21,30 +21,34 @@ class Tinyimg
     [width, height]
   end
 
-  def resize(width, height)
-    dup.resize!(width, height)
+  def resize(width:, height:)
+    dup.c_resize!(width, height)
   end
 
   # Implemented in C
-  # def resize!(width, height)
+  # def c_resize!(width, height)
   # end
 
-  def resize_to_fit(new_width, new_height)
-    dup.resize_to_fit!(new_width, new_height)
+  def resize!(width:, height:)
+    c_resize!(width, height)
   end
 
-  def resize_to_fit!(new_width, new_height)
-    resize_to_fit_or_fill!(new_width, new_height) do |old_ratio, new_ratio|
+  def resize_to_fit(width:, height:)
+    dup.resize_to_fit!(width: width, height: height)
+  end
+
+  def resize_to_fit!(width:, height:)
+    resize_to_fit_or_fill!(width: width, height: height) do |old_ratio, new_ratio|
       old_ratio > new_ratio
     end
   end
 
-  def resize_to_fill(new_width, new_height)
-    dup.resize_to_fill!(new_width, new_height)
+  def resize_to_fill(width:, height:)
+    dup.resize_to_fill!(width, height)
   end
 
-  def resize_to_fill!(new_width, new_height)
-    resize_to_fit_or_fill!(new_width, new_height) do |old_ratio, new_ratio|
+  def resize_to_fill!(width:, height:)
+    resize_to_fit_or_fill!(width: width, height: height) do |old_ratio, new_ratio|
       old_ratio < new_ratio
     end
   end
@@ -88,19 +92,19 @@ class Tinyimg
     end
   end
 
-  def resize_to_fit_or_fill!(new_width, new_height)
-    old_ratio = width / height.to_f
-    new_ratio = new_width / new_height.to_f
+  def resize_to_fit_or_fill!(width:, height:)
+    old_ratio = self.width / self.height.to_f
+    new_ratio = width / height.to_f
 
     if yield(old_ratio, new_ratio)
-      resize_width = new_width
-      resize_height = (height * (new_width / width.to_f)).to_i
+      resize_width = width
+      resize_height = (self.height * (width / self.width.to_f)).to_i
     else
-      resize_width = (width * (new_height / height.to_f)).to_i
-      resize_height = new_height
+      resize_width = (self.width * (height / self.height.to_f)).to_i
+      resize_height = height
     end
 
-    resize!(resize_width, resize_height)
+    c_resize!(resize_width, resize_height)
   end
 
   def determine_type(data)

--- a/lib/tinyimg.rb
+++ b/lib/tinyimg.rb
@@ -1,4 +1,4 @@
-require_relative '../ext/tinyimg/tinyimg'
+require 'tinyimg/tinyimg'
 
 class Tinyimg
   attr_reader :width, :height

--- a/spec/tinyimg_spec.rb
+++ b/spec/tinyimg_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Tinyimg do
 
   describe "#resize" do
     it "resizes the image as requested, creating a new image" do
-      result = sample.resize(100, 100)
+      result = sample.resize(width: 100, height: 100)
       expect(result).to_not eql sample
       expect(sample.dimensions).to eq [200, 153]
       expect(result.dimensions).to eq [100, 100]
@@ -44,7 +44,15 @@ RSpec.describe Tinyimg do
 
   describe "#resize!" do
     it "resizes the image as requested" do
-      result = sample.resize!(100, 100)
+      result = sample.resize!(width: 100, height: 100)
+      expect(result).to eql sample
+      expect(sample.dimensions).to eq [100, 100]
+    end
+  end
+
+  describe "#c_resize!" do
+    it "resizes the image as requested directly using the method implemented in C" do
+      result = sample.c_resize!(100, 100)
       expect(result).to eql sample
       expect(sample.dimensions).to eq [100, 100]
     end
@@ -52,24 +60,24 @@ RSpec.describe Tinyimg do
 
   describe "#resize_to_fit!" do
     it "calculates the image dimensions so it fits the width and resizes" do
-      sample.resize_to_fit!(100, 100)
+      sample.resize_to_fit!(width: 100, height: 100)
       expect(sample.dimensions).to eq [100, 76]
     end
 
     it "calculates the image dimensions so it fits the height and resizes" do
-      sample.resize_to_fit!(1000, 100)
+      sample.resize_to_fit!(width: 1000, height: 100)
       expect(sample.dimensions).to eq [130, 100]
     end
   end
 
   describe "#resize_to_fill!" do
     it "calculates the image dimensions so it fills the width and resizes" do
-      sample.resize_to_fill!(1000, 100)
+      sample.resize_to_fill!(width: 1000, height: 100)
       expect(sample.dimensions).to eq [1000, 765]
     end
 
     it "calculates the image dimensions so it fills the height and resizes" do
-      sample.resize_to_fill!(100, 100)
+      sample.resize_to_fill!(width: 100, height: 100)
       expect(sample.dimensions).to eq [130, 100]
     end
   end

--- a/tinyimg.gemspec
+++ b/tinyimg.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.extensions    = %w(ext/tinyimg/extconf.rb)
 
-  gem.required_ruby_version = '>= 2.0.0'
+  gem.required_ruby_version = '>= 2.1.0'
 
   gem.add_development_dependency "rspec", "~> 3.0"
 end


### PR DESCRIPTION
We can now avoid the confusion/ambiguity that comes with width and height argument ordering.
This change means that the project will rely on ruby 2.1+ .
